### PR TITLE
Handle large packets

### DIFF
--- a/PktConverter/Source.cpp
+++ b/PktConverter/Source.cpp
@@ -71,7 +71,7 @@ class Converter
             {
                 printf("\r%u               ", ++counter);
 
-                StringVector m = get_matches(buf, "^Time: ([0-9]+,?[0-9]+?);OpcodeType: (ClientMessage|ServerMessage);OpcodeValue: ([0-9]+);Packet: ([0-9A-Z]*);$");
+                StringVector m = get_matches(buf, "Time: (.*?);OpcodeType: (ClientMessage|ServerMessage);OpcodeValue: ([0-9]+);Packet: ([0-9A-Z]*);");
                 if (!m.size())
                 {
                     std::cout << std::endl << "ERROR: wrong format at line " << counter << ". Skipping." << std::endl;


### PR DESCRIPTION
Fix "The complexity of an attempted match against a regular expression exceeded a pre-set level." error when packets are too large

Tested successfully on 667267 hex characters packets